### PR TITLE
add export of Image component

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -14,6 +14,7 @@ export * from './Tabs'
 export * from './Textarea'
 export * from './DatePicker'
 export * from './DateTimePicker'
+export * from './Image'
 
 
 export { default as Button } from './Button'
@@ -32,3 +33,4 @@ export { default as Tabs } from './Tabs'
 export { default as Textarea } from './Textarea'
 export { default as DatePicker } from './DatePicker'
 export { default as DateTimePicker } from './DateTimePicker'
+export { default as Image } from './Image'


### PR DESCRIPTION
Hey, I was using the component library and noticed the image component is not exported from the components folder, would this be enough to fix it?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Image component is now exposed as a top-level export, supporting both default and named imports for simpler and more consistent usage. No behavior changes or breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->